### PR TITLE
New config improve design

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in hop_hop.gemspec
 gemspec
-
-group :developemnt do
-  gem 'rubocop', "0.26.0", :require => false
-end

--- a/lib/hop_hop/bunny_sender.rb
+++ b/lib/hop_hop/bunny_sender.rb
@@ -2,6 +2,9 @@ module HopHop
   # This sends an event through Bunny
   # it jsons the data and passes the meta header as is
   class BunnySender
+
+    RETRIES_AFTER_FAILURE = 3
+
     attr_reader :options
 
     # @param [Hash] options
@@ -20,39 +23,36 @@ module HopHop
 
       @options = defaults.merge(options)
       @exchange_name = options[:events] || 'events'
-      @reset_mutex = Mutex.new
-      exchange
+      @channel_mutex = Monitor.new
     end
 
     # @param [Object] data is an object that responds to to_json
     # @param [Hash] meta a hash of meta informations (see HopHop::Event#meta)
     def publish(data, meta)
-      meta = meta.merge(expiration: options[:ttl]) if options[:ttl]
-      tries = 3
-      begin
-        exchange.publish(data.to_json, meta)
-        # I have to rescue these and retry as bunny's autoreconnect sometimes simply doesn't work
-        # TBD: logging this would be good
-      rescue Bunny::ConnectionClosedError, Bunny::ChannelAlreadyClosed
-        sleep 0.3
-        if @reset_mutex.try_lock
-          tries -= 1
+      @channel_mutex.synchronize do
+        meta = meta.merge(expiration: options[:ttl]) if options[:ttl]
+        remaining_tries = RETRIES_AFTER_FAILURE
+        begin
+          exchange.publish(data.to_json, meta)
+            # I have to rescue these and retry as bunny's autoreconnect sometimes simply doesn't work
+            # TBD: logging this would be good
+        rescue Bunny::ConnectionClosedError, Bunny::ChannelAlreadyClosed
+          sleep 0.3
+          remaining_tries -= 1
           reset
-          @reset_mutex.unlock
-          tries >= 0 ? retry : raise
-        else
-          sleep 1
-          retry
+          remaining_tries > 0 ? retry : raise
         end
       end
     end
 
-    private
-
     def reset
-      @exchange = @channel = @connection = nil
-      exchange
+      @channel_mutex.synchronize do
+        @exchange = @channel = @connection = nil
+        exchange
+      end
     end
+
+    private
 
     def exchange
       @exchange ||= channel.topic(@exchange_name, durable: true)

--- a/lib/hop_hop/consumer_bin.rb
+++ b/lib/hop_hop/consumer_bin.rb
@@ -20,7 +20,7 @@ module HopHop
         exit(1)
       end
 
-      @command = ARGV.shift
+      @command = argv.shift
       unless KNOWN_COMMANDS.include?(@command)
         STDERR.puts "command unknown: '#{@command}' must be one of #{KNOWN_COMMANDS.join(", ")}."
         STDERR.puts options_parser

--- a/spec/lib/hop_hop/bunny_sender_spec.rb
+++ b/spec/lib/hop_hop/bunny_sender_spec.rb
@@ -2,11 +2,21 @@ require 'spec_helper'
 require 'json'
 
 describe HopHop::QueueConnection, :rabbitmq do
+
+  subject(:sender){ HopHop::BunnySender.new.tap{|s| s.reset}}
+  def sender_connection; sender.send(:connection) end # I know this a dirty way to get the connection
+  def sender_publishes_msg; sender.publish({ :ok => 1 }, {})  end
+
   it "should retry if connection is closed" do
-    sender=HopHop::BunnySender.new
-    sender.publish({ :ok => 1},{})
-    connection=sender.send(:connection) #I now this a dirty way to get the connection
-    connection.close
-    expect do sender.publish({ :ok => 1},{}) end.not_to raise_error
+    sender_connection.close
+    expect{sender_publishes_msg}.not_to raise_error
   end
+
+  it "raises error if connection still not working after reset" do
+    allow(sender).to receive(:reset).and_return(nil)
+    sender_connection.close
+    expect{sender_publishes_msg}.to raise_exception
+    expect(sender).to have_received(:reset).exactly(HopHop::BunnySender::RETRIES_AFTER_FAILURE).times
+  end
+
 end


### PR DESCRIPTION
synchronized the public methods of BunnySender (publish & reset);
As there is no need to setup the channel at startup now (because all access to BunnySender is synchronized), I changed it back to the behaviour of 0.7.0, the exchange gets set up when the first message is send.
