### PR TITLE
New config improve design

### DIFF
--- a/lib/hop_hop/consumer_server.rb
+++ b/lib/hop_hop/consumer_server.rb
@@ -27,6 +27,7 @@ module HopHop
     # @param [integer] instances how many instances to fire up (not taken from the config)
     def consumer(consumer_class_name, required_count_running)
       consumer_config = @config.consumers[consumer_class_name]
+      return unless consumer_config
 
       instance_ids = instances(consumer_config.class_name)
       count_running = instance_ids.size
@@ -60,6 +61,7 @@ module HopHop
     # @return [Hash] returns an array identifiers
     def instances(consumer_class_name)
       consumer_config = @config.consumers[consumer_class_name]
+      return [] unless consumer_config
       @config.driver.instance_ids(@config, consumer_config)
     end
 

--- a/lib/hop_hop/queue_connection.rb
+++ b/lib/hop_hop/queue_connection.rb
@@ -112,13 +112,13 @@ module HopHop
     # @return [Bunny::Session] active Bunny session
     def connection
       return @connection if defined?(@connection)
-      @connection = Bunny.new(Helper.slice_hash(@options, :host, :port, :virtual_host, :heartbeat, 
+      @connection = Bunny.new(Helper.slice_hash(@options, :host, :port, :virtual_host, :heartbeat,
                                                 :automatically_recover,:user,:password))
       @connection.start
       @connection
     end
 
-  private
+    private
 
     def metadata(delivery_info, properties)
       {
@@ -149,6 +149,14 @@ Consumer failed (#{strategy}): #{consumer.name} #{error.message}
 #{event.inspect}
 EOF
       normal_exit
+    rescue StandardError => error
+      logger.fatal(<<-EOF)
+Fatal error in on_error method, consumer exiting:
+#{error.inspect}
+#{error.backtrace.join("\n")}
+#{event.inspect}
+EOF
+      on_error_exit(delivery_info)
     end
 
     # acknowledge and go on


### PR DESCRIPTION
2 bugfixes: 
* 8ee596d catches any error raised in the error handling itself (i.e. the on_error callback ), logs it to the consumer log and exits the consumer normally. Previously error messages were hidden in the hop_hop_prefork_stdout.log with no clear connection to the specific consumer and the crashed consumer appeared to be still running (although frozen).



* 945da85 fixes a gotcha that often happened when writing / deploying a new consumer. On each call of the hop_hop executable, the hop_hop executable would load config file anew, but a already running  hop_hop server wouldn't reload the changed config and code (e.g. a new consumer), eventually resulting in crashing the executable (making it necessary to kill the hop_hop server or temporarily changing the config in order to start the new consumer). 

    So if you had a hop_hop server running, then created a new consumer, added it to the config and finally ran hop_hop restart|stop, the hop_hop executable (ConsumerCtrl) would make a remote call to the server, requesting to stop|start the new consumer. But because the new consumer was not yet present in the outdated config of the hop_hop server, you would get a NoMethodError somewhere along the way.
 

